### PR TITLE
Add projects to UserProfile

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -39,18 +39,8 @@ export default () => (
           () => <Register version={null} /> // set custom 'chingu_application' version here
         }
       />
-      <Private exact path="/profile" render={() => <UserProfile editable={true} />} />
-      <Route
-        exact path="/profile/:username"
-        render={
-          ({ match: { params: { username } } }) => (
-            <UserProfile
-              username={username}
-              editable={false}
-            />
-          )
-        }
-      />
+      <Private exact path="/profile" component={UserProfile} />
+      <Route exact path="/profile/:username" component={UserProfile} />
       <Private exact path="/voyage" component={VoyagePortal} />
       <Private
         exact path="/voyage/application/:voyage_id"

--- a/src/components/FeedPortal/components/TeamCard.jsx
+++ b/src/components/FeedPortal/components/TeamCard.jsx
@@ -37,9 +37,9 @@ const InfoComponents = ({ team }) => {
   let cohort = team.cohort;
   let project = team.project;
   let infoObjects = [
-    { label: 'Voyage Dates', data: dateFormatter(cohort.start_date) + " - " + dateFormatter(cohort.end_date) },
+    { label: 'Voyage', data: `${cohort.title} - ${dateFormatter(cohort.start_date)} - ${dateFormatter(cohort.end_date)}` },
     { label: 'Status', data: cohort.status },
-    { label: 'Team Name', data: team.title },
+    { label: 'Team', data: team.title },
     { label: 'Tier', data: 'Tier ' + team.tier.level },
     { label: 'Project', data: project.title },
     { label: 'Elevator Pitch', data: project.elevator_pitch },

--- a/src/components/FeedPortal/components/TeamCard.jsx
+++ b/src/components/FeedPortal/components/TeamCard.jsx
@@ -37,20 +37,23 @@ const InfoComponents = ({ team }) => {
   let cohort = team.cohort;
   let project = team.project;
   let infoObjects = [
-    { label: 'Team Name', data: team.title },
     { label: 'Voyage Dates', data: dateFormatter(cohort.start_date) + " - " + dateFormatter(cohort.end_date) },
     { label: 'Status', data: cohort.status },
+    { label: 'Team Name', data: team.title },
     { label: 'Tier', data: 'Tier ' + team.tier.level },
-    { label: 'Team', data: project.users },
     { label: 'Project', data: project.title },
     { label: 'Elevator Pitch', data: project.elevator_pitch },
+    { label: 'Members', data: project.users },
     // { label: 'TechStack', data: project.skills },
   ]
 
   return infoObjects.map((info, idx) => {
     let data;
     switch (info.label) {
-      case 'Team':
+      case "Tier":
+        data = <span key={idx} className="tier-icon">{info.data}</span>
+        break;
+      case 'Members':
         data = info.data.map((user, idx) => {
           return (
             <Link to={`/profile/${user.username}`} key={idx} className="team-card-user">

--- a/src/components/FeedPortal/components/TeamCard.scss
+++ b/src/components/FeedPortal/components/TeamCard.scss
@@ -6,7 +6,7 @@
     padding: 40px 0px 40px 30px;
     display: grid;
     grid-template-columns: repeat(5, 1fr);
-    grid-gap: 20px;
+    grid-gap: 24px;
 }
 
 /*
@@ -67,6 +67,7 @@ INFO CONTAINER
     font-size: 14px;
     color: $lighter-grey;
     text-transform: uppercase;
+    align-self: center;
 }
 
 .team-card-info--data {
@@ -102,10 +103,9 @@ USER IMAGES
 */
 .team-card-user {
     width: 45px;
-    height: 60px;
+    height: 45px;
     display: inline-block;
-    margin-right: 14px;
-    margin-bottom: 10px;
+    margin: auto 10px 10px auto;
 }
 .team-card-avatar-img {
     margin: 0 auto;

--- a/src/components/FeedPortal/components/TeamCard.scss
+++ b/src/components/FeedPortal/components/TeamCard.scss
@@ -86,6 +86,15 @@ INFO CONTAINER
     padding: 5px 10px;
     text-transform: capitalize;
 }
+
+.tier-icon {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: $health-green;
+  border: 1px solid $health-green;
+  padding: 3px 7px;
+  margin: 2px auto;
+}
 /*
 ==========================
 USER IMAGES

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -8,23 +8,23 @@
   background: white;
   max-width: $max-width;
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  grid-template-areas: "i i v v v";
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-areas: "info project project";
   margin: 0 auto;
   margin-top: 150px;
-  grid-gap: 100px;
+  grid-gap: 60px;
   min-height: 100vh;
   margin-bottom: 100px;
-  // padding: 20px;
+  padding: 20px;
 }
 
 .user-profile {
-  grid-area: i;
+  grid-area: info;
 }
 
 .user-voyages {
   width: 100%;
- grid-area: v;
+ grid-area: project;
  justify-self: center;
 }
 
@@ -44,22 +44,78 @@
   box-shadow: $box-shadow;
   padding: 40px 20px;
   width: 100%;
-  // border-radius: $border-radius;
   font-size: 20px;
   text-align: center;
   border: 1px solid $light-grey;
 }
+/*
+==========================
+PROJECT CARDS
+==========================
+*/
+.project-card__container {
+  width: 100%;
+  box-shadow: $box-shadow;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-areas: "image info";
+  background-color: white;
+}
 
+.project-img {
+  grid-area: image;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.project-info__container {
+  grid-area: info;
+  font-size: 14px;
+  padding: 30px;
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  grid-gap: 10px;
+  align-items: center;
+  justify-items: start;
+}
+
+.project-info__label {
+  grid-column: 1 / 2;
+  font-size: 14px;
+  color: $lighter-grey;
+  text-transform: uppercase;
+  align-self: start;
+}
+
+.project-info__data {
+  grid-column: 2 / -1;
+  font-size: 14px;
+  color: $dark-grey;
+  max-height: 100px;
+  align-items: start;
+  min-height: 28px;
+  text-align: left;
+}
+
+.tier-icon {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: $health-green;
+  border: 1px solid $health-green;
+  padding: 3px 7px;
+  margin: 2px auto;
+}
 /*
 ==========================
 MEDIA QUERY
 ==========================
 */
-@media (max-width: 1000px) {
+@media (max-width: 1000px) and (min-width: 0px) {
   .user-profile-container {
     grid-template-columns: repeat(1, 1fr);
-    grid-template-areas: "i"
-                          "v";
+    grid-template-areas: "info"
+                          "project";
     margin-top: 100px;
     padding: 0px;
     grid-gap: 100px;
@@ -77,55 +133,16 @@ MEDIA QUERY
   .user-voyage-title {
     text-align: center;
   }
+  .project-card__container {
+    margin: 0 auto;
+    max-width: 500px;
+    grid-template-columns: repeat(1, 1fr);
+    grid-template-areas: "image" "info";
+    margin-bottom: 20px;
+  } 
 }
-
-// PROJECT CARD //
-.project-card__container {
-  width: 710px;
-  box-shadow: $box-shadow;
-  display: grid;
-  padding-right: 20px;
-  grid-template-columns: repeat(2, auto);
-  grid-gap: 20px;
-  background-color: white;
-}
-
-.project-img {
-  width: 325px;
-  height: 100%;
-  object-fit: cover;
-}
-
-.project-info__container {
-  font-size: 14px;
-  width: 385px;
-  padding: 20px;
-  display: grid;
-  grid-template-columns: repeat(2, auto);
-  grid-gap: 10px;
-}
-
-.project-info__label {
-  grid-column: 1 / 2;
-  font-size: 14px;
-  color: $lighter-grey;
-  text-transform: uppercase;
-  align-self: center
-}
-
-.project-info__data {
-  grid-column: 2 / -1;
-  font-size: 14px;
-  color: $dark-grey;
-  max-height: 100px;
-  align-items: start;
-}
-
-.tier-icon {
-  font-size: 12px;
-  text-transform: uppercase;
-  color: $health-green;
-  border: 1px solid $health-green;
-  padding: 3px 7px;
-  margin: 2px auto;
+@media (max-width: 500px) and (min-width: 0px) {
+  .project-card__container {
+    width: 90vw;
+  } 
 }

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -79,19 +79,21 @@ MEDIA QUERY
   }
 }
 
-
+// PROJECT CARD //
 .project-card__container {
   width: 710px;
-  min-height: 260px;
+  // min-height: 260px;
   box-shadow: $box-shadow;
   display: grid;
   margin-bottom: 10px;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, auto);
   grid-gap: 20px;
+  background-color: white;
 }
 
 .project-img {
   width: 325px;
+  object-fit: cover;
   // TODO: Crop
 }
 
@@ -100,8 +102,9 @@ MEDIA QUERY
   width: 385px;
   padding: 20px;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, auto);
   grid-gap: 10px;
+  margin-bottom: 10px;
 }
 
 .project-info__label {

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -121,3 +121,11 @@ MEDIA QUERY
   max-height: 100px;
   align-items: start;
 }
+
+.tier-icon {
+  color: $health-green;
+  border: 1px solid $health-green;
+  padding: 5px 7px;
+  font-size: 12px;
+  text-transform: uppercase;
+}

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -8,11 +8,11 @@
   background: white;
   max-width: $max-width;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-areas: "info project project";
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-areas: "info project project project";
   margin: 0 auto;
   margin-top: 150px;
-  grid-gap: 60px;
+  grid-gap: 80px;
   min-height: 100vh;
   margin-bottom: 100px;
   padding: 20px;

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -123,9 +123,10 @@ MEDIA QUERY
 }
 
 .tier-icon {
-  color: $health-green;
-  border: 1px solid $health-green;
-  padding: 5px 7px;
   font-size: 12px;
   text-transform: uppercase;
+  color: $health-green;
+  border: 1px solid $health-green;
+  padding: 3px 7px;
+  margin: 2px auto;
 }

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -78,3 +78,43 @@ MEDIA QUERY
     text-align: center;
   }
 }
+
+
+.project-card__container {
+  width: 710px;
+  min-height: 260px;
+  box-shadow: $box-shadow;
+  display: grid;
+  margin-bottom: 10px;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 20px;
+}
+
+.project-img {
+  width: 325px;
+  // TODO: Crop
+}
+
+.project-info__container {
+  font-size: 14px;
+  width: 385px;
+  padding: 20px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 10px;
+}
+
+.project-info__label {
+  grid-column: 1 / 2;
+  font-size: 14px;
+  color: $lighter-grey;
+  text-transform: uppercase;
+
+}
+.project-info__data {
+  grid-column: 2 / -1;
+  font-size: 14px;
+  color: $dark-grey;
+  max-height: 100px;
+  align-items: start;
+}

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -82,10 +82,9 @@ MEDIA QUERY
 // PROJECT CARD //
 .project-card__container {
   width: 710px;
-  // min-height: 260px;
   box-shadow: $box-shadow;
   display: grid;
-  margin-bottom: 10px;
+  padding-right: 20px;
   grid-template-columns: repeat(2, auto);
   grid-gap: 20px;
   background-color: white;
@@ -104,7 +103,6 @@ MEDIA QUERY
   display: grid;
   grid-template-columns: repeat(2, auto);
   grid-gap: 10px;
-  margin-bottom: 10px;
 }
 
 .project-info__label {
@@ -112,8 +110,9 @@ MEDIA QUERY
   font-size: 14px;
   color: $lighter-grey;
   text-transform: uppercase;
-
+  align-self: center
 }
+
 .project-info__data {
   grid-column: 2 / -1;
   font-size: 14px;

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -111,7 +111,7 @@ PROJECT CARDS
 MEDIA QUERY
 ==========================
 */
-@media (max-width: 1000px) and (min-width: 0px) {
+@media (max-width: 1020px) and (min-width: 0px) {
   .user-profile-container {
     grid-template-columns: repeat(1, 1fr);
     grid-template-areas: "info"

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -93,8 +93,8 @@ MEDIA QUERY
 
 .project-img {
   width: 325px;
+  height: 100%;
   object-fit: cover;
-  // TODO: Crop
 }
 
 .project-info__container {

--- a/src/components/UserProfile/UserSideBar.jsx
+++ b/src/components/UserProfile/UserSideBar.jsx
@@ -3,64 +3,7 @@ import './UserSideBar.css'
 import EditableTextField from '../utilities/EditableTextField';
 import { gql } from "apollo-boost";
 
-class UserSideBar extends React.Component {
-  state = {
-    user: null,
-    editable: false,
-  }
-
-  updateState = () => {
-    const { user, editable } = this.props;
-    this.setState({
-      user,
-      editable
-    });
-  }
-  componentDidMount() {
-    this.updateState();
-  }
-
-  componentDidUpdate(prevProps) {
-    if (
-      this.props.editable !== prevProps.editable
-      || this.props.user !== prevProps.user
-    ) {
-      this.updateState();
-    }
-  }
-
-  render() {
-    const { user, editable } = this.state;
-    if (!user) return null;
-    return (
-      <div className="user-profile-container-personal">
-        <header className="user">
-          <div className="photobox">
-            <img
-              className="user-photo"
-              src={user ? user.avatar : require('../../assets/blank image.png')}
-              alt="userprofile"
-            />
-            <p>{user.username}</p>
-            <p>Based in {user.country}</p>
-          </div>
-          <ul className="positions">
-            <li className="position">
-              <span>
-                <i className="fas fa-check" />
-              </span>Programmer
-              </li>
-          </ul>
-        </header>
-        <UserInfo user={user} editable={editable} />
-        <Links user={user} />
-      </div>
-    );
-  }
-}
-
-export default UserSideBar;
-
+// -- MUTATION -- //
 const userUpdate = gql`
 mutation userUpdate($user_data: UserUpdateInput!) {
   userUpdate(user_data: $user_data) {
@@ -72,6 +15,7 @@ mutation userUpdate($user_data: UserUpdateInput!) {
 }
 `;
 
+// -- USERINFO ELEMENTS -- //
 const USER_INFO_DOM_ELEMENTS = [
   {
     divClassName: 'user-background',
@@ -90,19 +34,17 @@ const USER_INFO_DOM_ELEMENTS = [
   },
 ];
 
-
 const UserInfo = ({ user, editable }) => {
   return USER_INFO_DOM_ELEMENTS.map((elem, idx) => {
-    const userComponent = ({ data }) => {
-      return (
-        <div key={idx} className={elem.divClassName}>
-          <h1 className="user-sidebar-subcategory">{elem.desc}</h1>
-          <p>{data}</p>
-        </div>
-      )
-    }
-    return editable // only render EditableTextField if editable
-      ? (
+    const UserComponent = props =>
+      <div key={idx} className={elem.divClassName}>
+        <h1 className="user-sidebar-subcategory">{elem.desc}</h1>
+        {props.children}
+      </div>
+
+    return !editable // only render EditableTextField if editable
+      ? <UserComponent key={idx}>{user[elem.schemaKey]}</UserComponent>
+      : (
         <EditableTextField
           key={idx}
           large
@@ -112,10 +54,9 @@ const UserInfo = ({ user, editable }) => {
           fieldName={elem.schemaKey}
           fieldData={user[elem.schemaKey]}
           hasPermission={editable}
-          component={userComponent}
+          component={UserComponent}
         />
       )
-      : userComponent({ data: user[elem.schemaKey] })
   });
 }
 
@@ -131,17 +72,100 @@ const Links = ({ user: { username } }) => (
     </ul>
   </div>
 );
-  // let skillDOM = null;
-  // if (user.skills && user.skills.length > 0) {
-  //   skillDOM = (
-  //     <div className="user-skills">
-  //       <h1 className="user-sidebar-subcategory">skills</h1>
-  //       <ul>
-  //         {user.skills.map(elem => (<li>{elem}</li>))}
-  //       </ul>
-  //     </div>
-  //   )
-  // }
 
-  // once links are integrated again, render this
-  // check for fb/linkedin/gitub
+
+// -- USER SIDEBAR (EXPORT)-- // 
+const UserSideBar = ({ user, editable }) => (
+  <div className="user-profile-container-personal">
+    <header className="user">
+      <div className="photobox">
+        <img
+          className="user-photo"
+          src={user ? user.avatar : require('../../assets/blank image.png')}
+          alt="userprofile" />
+        <p>{user.username}</p>
+        <p>Based in {user.country}</p>
+      </div>
+      <ul className="positions">
+        <li className="position">
+          <span><i className="fas fa-check" /></span>
+          Programmer
+        </li>
+      </ul>
+    </header>
+    <UserInfo user={user} editable={editable} />
+    <Links user={user} />
+  </div>
+);
+
+// class UserSideBar extends React.Component {
+//   state = {
+//     user: null,
+//     editable: false,
+//   }
+
+//   updateState = () => {
+//     this.setState({
+//       user,
+//       editable
+//     });
+//   }
+//   componentDidMount() {
+//     this.updateState();
+//   }
+
+//   componentDidUpdate(prevProps) {
+//     if (
+//       this.props.editable !== prevProps.editable
+//       || this.props.user !== prevProps.user
+//     ) {
+//       this.updateState();
+//     }
+//   }
+
+//   render() {
+//     const { user, editable } = this.state;
+//     if (!user) return null;
+//     return (
+//       <div className="user-profile-container-personal">
+//         <header className="user">
+//           <div className="photobox">
+//             <img
+//               className="user-photo"
+//               src={user ? user.avatar : require('../../assets/blank image.png')}
+//               alt="userprofile"
+//             />
+//             <p>{user.username}</p>
+//             <p>Based in {user.country}</p>
+//           </div>
+//           <ul className="positions">
+//             <li className="position">
+//               <span>
+//                 <i className="fas fa-check" />
+//               </span>Programmer
+//               </li>
+//           </ul>
+//         </header>
+//         <UserInfo user={user} editable={editable} />
+//         <Links user={user} />
+//       </div>
+//     );
+//   }
+// }
+
+export default UserSideBar;
+
+// let skillDOM = null;
+// if (user.skills && user.skills.length > 0) {
+//   skillDOM = (
+//     <div className="user-skills">
+//       <h1 className="user-sidebar-subcategory">skills</h1>
+//       <ul>
+//         {user.skills.map(elem => (<li>{elem}</li>))}
+//       </ul>
+//     </div>
+//   )
+// }
+
+// once links are integrated again, render this
+// check for fb/linkedin/gitub

--- a/src/components/UserProfile/graphql/profileQuery.js
+++ b/src/components/UserProfile/graphql/profileQuery.js
@@ -41,10 +41,14 @@ const profileQuery = gql`
         project {
             id
             title
-            description
+            elevator_pitch
+            images {
+              id
+              url
+            }
             users {
-                username
-                avatar
+              username
+              avatar
             }
         }
       }

--- a/src/components/UserProfile/index.jsx
+++ b/src/components/UserProfile/index.jsx
@@ -55,23 +55,6 @@ const InfoComponents = ({ team }) => {
   })
 }
 
-const ProjectCard = ({ team }) => {
-  const { images } = team.project
-  return (
-    <div className="project-card__container">
-      <Link to={`/project/${team.project.id}`}>
-        <img
-          className="project-img"
-          src={images[0] ? images[0].url : require('../../assets/landingImage.png')} />
-      </Link>
-      <div className="project-info__container">
-        <InfoComponents team={team} />
-      </div>
-    </div>
-  )
-}
-
-
 
 // -- USER PROFILE (EXPORT) -- //
 const UserProfile = props => {
@@ -89,16 +72,6 @@ const UserProfile = props => {
     cohort.members.some(member =>
       member.user.username === username && member.status === "pending_approval"
     ))
-
-  const renderProjectCards = (currentTeams, pastTeams) => {
-    const mapProjectCards = teamsList => teamsList.map(team => <ProjectCard key={team.project.id} team={team} />)
-    return <Fragment>
-      {!!currentTeams.length && <div className="user-voyage-title">Current Projects</div>}
-      {mapProjectCards(currentTeams)}
-      {!!pastTeams.length && <div className="user-voyage-title">Past Projects</div>}
-      {mapProjectCards(pastTeams)}
-    </Fragment>
-  }
 
   const renderCurrentTeam = currentTeams => {
     let card = currentTeams.length > 0 && currentTeams.map((team, index) => {
@@ -163,6 +136,22 @@ const UserProfile = props => {
     )
   }
 
+  const renderProjectCards = teamsList => teamsList.map(team => {
+    const { id, images } = team.project
+    return (
+      <Link key={id} to={`/project/${id}`}>
+        <div className="project-card__container">
+          <img
+            className="project-img"
+            src={images[0] ? images[0].url : require('../../assets/landingImage.png')} />
+          <div className="project-info__container">
+            <InfoComponents team={team} />
+          </div>
+        </div>
+      </Link>
+    )
+  })
+
   return (
     < div className="user-profile-background-color" >
       <div className="user-profile-container">
@@ -185,7 +174,10 @@ const UserProfile = props => {
             }
           </section>
           <section>
-            {renderProjectCards(currentTeams, pastTeams)}
+            {!!currentTeams.length && <div className="user-voyage-title">Current Projects</div>}
+            {renderProjectCards(currentTeams)}
+            {!!pastTeams.length && <div className="user-voyage-title">Past Projects</div>}
+            {renderProjectCards(pastTeams)}
           </section>
         </main>
       </div>

--- a/src/components/UserProfile/index.jsx
+++ b/src/components/UserProfile/index.jsx
@@ -12,11 +12,11 @@ import dateFormatter from "../utilities/dateFormatter.js"
 const InfoComponents = ({ team }) => {
   const { project, cohort, tier, title } = team
   const infoObjects = [
-    { label: 'Voyage', data: `${cohort.title} - ${dateFormatter(cohort.start_date)} - ${dateFormatter(cohort.end_date)}` },
+    { label: 'Voyage', data: `${cohort.title} / ${dateFormatter(cohort.start_date)} - ${dateFormatter(cohort.end_date)}` },
     { label: 'Team', data: title },
     { label: 'Tier', data: 'Tier ' + tier.level },
     { label: 'Project', data: project.title },
-    { label: 'Elevator Pitch', data: project.elevator_pitch },
+    { label: 'Description', data: project.elevator_pitch },
     { label: 'Members', data: project.users },
   ]
 
@@ -141,7 +141,7 @@ const UserProfile = props => {
     const { id, images } = team.project
     return (
       <div key={id} className="project-card__container">
-        <Link to={`/project/${id}`}>
+        <Link className="project-img" to={`/project/${id}`}>
           <img
             className="project-img"
             src={images[0] ? images[0].url : require('../../assets/landingImage.png')} />

--- a/src/components/UserProfile/index.jsx
+++ b/src/components/UserProfile/index.jsx
@@ -14,18 +14,19 @@ const InfoComponents = ({ team }) => {
   const infoObjects = [
     { label: 'Voyage Dates', data: dateFormatter(cohort.start_date) + " - " + dateFormatter(cohort.end_date) },
     { label: 'Team Name', data: title },
+    { label: 'Tier', data: 'Tier ' + tier.level },
     { label: 'Project', data: project.title },
     { label: 'Elevator Pitch', data: project.elevator_pitch },
-    { label: 'Tier', data: 'Tier ' + tier.level },
-    { label: 'Team', data: project.users },
-    // { label: 'Status', data: cohort.status },
-    // { label: 'TechStack', data: project.skills },
+    { label: 'Members', data: project.users },
   ]
 
   return infoObjects.map((info, idx) => {
     let data;
     switch (info.label) {
-      case 'Team':
+      case "Tier":
+        data = <span key={idx} className="tier-icon">{info.data}</span>
+        break;
+      case 'Members':
         data = info.data.map((user, idx) => {
           return (
             <Link to={`/profile/${user.username}`} key={idx} className="team-card-user">
@@ -38,7 +39,7 @@ const InfoComponents = ({ team }) => {
       case 'TechStack':
         data = info.data && info.data.map((tech, idx) => {
           return (
-            <div key={idx} className="team-card-techstac k">{tech.name}</div>
+            <div key={idx} className="team-card-techstack">{tech.name}</div>
           )
         })
         break;
@@ -193,160 +194,3 @@ export default props =>
     component={UserProfile}
     globalLoader
   />
-
-
-// class UserProfile extends React.Component {
-//   state = {
-//     user: this.props.data.user,
-//     currentTeams: [],
-//     pastTeams: [],
-//     pendingApproval: [],
-//     editable: false
-//   }
-
-//   updateState = () => {
-//     let { data: { user }, editable } = this.props;
-//     this.setState({ user: user, editable: editable ? true : false }, () => {
-//       // TODO: Check filters
-//       let { user } = this.state;
-//       let { teams, cohorts } = user;
-//       let currentTeams = teams.filter(team => { return team.cohort.status === 'ongoing' });
-//       let pastTeams = teams.filter(team => { return team.cohort.status === 'ended' });
-
-//       let pendingApproval = cohorts.filter((cohort) => {
-//         let member = cohort.members.filter((member) => member.user.username === user.username && member.status === 'pending_approval');
-//         if (member.length >= 1) {
-//           return cohort;
-//         }
-//       });
-//       this.setState({ currentTeams, pastTeams, pendingApproval });
-//     })
-//   }
-//   componentDidMount() {
-//     this.updateState();
-//   }
-
-//   componentDidUpdate(prevProps) {
-//     if (this.props !== prevProps) {
-//       this.updateState();
-//     }
-//   }
-
-//   renderCurrentTeam = () => {
-//     let { currentTeams } = this.state;
-//     let card = currentTeams.length > 0 && currentTeams.map((team, index) => {
-//       return (
-//         <Cards.CurrentVoyageCardWithTeam
-//           key={team.id + "_" + index}
-//           voyageNumber={team.id}
-//           startDate={team.cohort.start_date}
-//           endDate={team.cohort.end_date}
-//           team={team}
-//         />
-//       )
-//     })
-//     return (
-//       <Fragment>
-//         <div className="user-voyage-title">Current Voyages</div>
-//         {card}
-//       </Fragment>
-//     )
-//   }
-
-//   renderPendingApproval = () => {
-//     let { pendingApproval } = this.state;
-//     return pendingApproval.map((cohort, index) => {
-//       return (
-//         <Fragment key={cohort.id + "_" + index}>
-//           <div className="user-voyage-title">Upcoming Voyages</div>
-//           <Cards.PendingApprovalVoyageCard
-//             key={cohort.id + "_" + index}
-//             voyageNumber={cohort.id}
-//             startDate={cohort.start_date}
-//             endDate={cohort.end_date}
-//             cohort={cohort.title}
-//           />
-//         </Fragment>
-//       )
-//     })
-//   }
-//   renderNoTeamTypeCards = () => {
-//     let { user, currentTeams, pastTeams, pendingApproval, editable } = this.state;
-//     const NothingHere = () => {
-//       return (
-//         <div className="no-data-card">
-//           Nothing Here Yet! Check Back Later!
-//         </div>
-//       )
-//     }
-//     let card;
-//     if (editable && pendingApproval.length > 0) {
-//       console.log('in 1')
-//       return null;
-//     } else if (editable) {
-//       console.log('in 2')
-//       card = <Cards.ApplyForAVoyageCard />
-//     } else if (!editable && pendingApproval.length === 0) {
-//       console.log('in 3')
-//       card = <NothingHere />
-//     }
-//     return (
-//       <Fragment>
-//         <div className="user-voyage-title">Current Voyages</div>
-//         {card}
-//       </Fragment>
-//     )
-//   }
-//   render() {
-//     console.log("Profile", this.props)
-//     let { user, currentTeams, pastTeams, pendingApproval, editable } = this.state;
-//     return (
-//       <div className="user-profile-background-color" >
-//         <div className="user-profile-container">
-//           <aside className="user-profile">
-//             <UserSideBar editable={this.state.editable} user={user} />
-//           </aside>
-
-//           <main className="user-voyages">
-//             <section className="user-voyage">
-//               {
-//                 currentTeams.length > 0
-//                   ? this.renderCurrentTeam()
-//                   : this.renderNoTeamTypeCards()
-//               }
-//             </section>
-//             <section className="user-voyage">
-//               {
-//                 pendingApproval.length > 0
-//                 && this.renderPendingApproval()
-//               }
-//             </section>
-//           </main>
-//         </div>
-//       </div >
-//     )
-//   }
-
-// }
-
-
-// {
-//   pastTeams.length > 0
-//   && <section className="user-voyage">
-//     <div className="user-voyage-title">Past Voyages</div>
-//     <div>
-//       {pastTeams.map((team, index) => {
-//         return (
-//           <Cards.PreviousVoyageCardWithTeam
-//             key={team.id + "_" + index}
-//             voyageNumber={team.id}
-//             startDate={team.cohort.start_date}
-//             endDate={team.cohort.end_date}
-//             team={team.title}
-//           />
-//         )
-//       })}
-//     </div>
-//   </section>
-// }
-

--- a/src/components/UserProfile/index.jsx
+++ b/src/components/UserProfile/index.jsx
@@ -140,16 +140,16 @@ const UserProfile = props => {
   const renderProjectCards = teamsList => teamsList.map(team => {
     const { id, images } = team.project
     return (
-      <Link key={id} to={`/project/${id}`}>
-        <div className="project-card__container">
+      <div key={id} className="project-card__container">
+        <Link to={`/project/${id}`}>
           <img
             className="project-img"
             src={images[0] ? images[0].url : require('../../assets/landingImage.png')} />
-          <div className="project-info__container">
-            <InfoComponents team={team} />
-          </div>
+        </Link>
+        <div className="project-info__container">
+          <InfoComponents team={team} />
         </div>
-      </Link>
+      </div>
     )
   })
 

--- a/src/components/UserProfile/index.jsx
+++ b/src/components/UserProfile/index.jsx
@@ -1,16 +1,77 @@
 import * as React from "react";
+import { Link } from "react-router-dom"
 import * as Cards from "../VoyageCard/VoyageCard";
 import UserSideBar from "./UserSideBar";
 import Request from "../utilities/Request"
 import profileQuery from "./graphql/profileQuery"
 import './UserProfile.css'
+import dateFormatter from "../utilities/dateFormatter.js"
+
+const InfoComponents = ({ team }) => {
+  const { project, cohort, tier, title } = team
+  const infoObjects = [
+    { label: 'Voyage Dates', data: dateFormatter(cohort.start_date) + " - " + dateFormatter(cohort.end_date) },
+    { label: 'Team Name', data: title },
+    { label: 'Project', data: project.title },
+    { label: 'Elevator Pitch', data: project.elevator_pitch },
+    { label: 'Tier', data: 'Tier ' + tier.level },
+    { label: 'Team', data: project.users },
+    // { label: 'Status', data: cohort.status },
+    // { label: 'TechStack', data: project.skills },
+  ]
+
+  return infoObjects.map((info, idx) => {
+    let data;
+    switch (info.label) {
+      case 'Team':
+        data = info.data.map((user, idx) => {
+          return (
+            <Link to={`/profile/${user.username}`} key={idx} className="team-card-user">
+              <img className="team-card-avatar-img" src={user.avatar ? user.avatar : require('../../assets/blank image.png')} alt={user.username} />
+              <div className="team-card-username">{user.username}</div>
+            </Link>
+          )
+        })
+        break;
+      case 'TechStack':
+        data = info.data && info.data.map((tech, idx) => {
+          return (
+            <div key={idx} className="team-card-techstac k">{tech.name}</div>
+          )
+        })
+        break;
+      default:
+        data = info.data;
+        break;
+    }
+    return (
+      <React.Fragment key={idx} >
+        <div className="project-info__label">{info.label}</div>
+        <div className="project-info__data">{data}</div>
+      </React.Fragment>
+    )
+  })
+}
+
+const ProjectCard = ({ team }) => {
+  return (
+    <div className="project-card__container">
+      <img
+        className="project-img"
+        src="https://placehold.it/325x260" />
+      <div className="project-info__container">
+        <InfoComponents team={team} />
+      </div>
+    </div>
+  )
+}
 
 const UserProfile = props => {
   // Only allow editing if no /profile param provided. TODO: Check for currently logged in user
   const editable = !props.match.params.username
 
   /**
-   * TODOS: 
+   * TODOS:
    * Check filters
    * Fix pendingApproval filter (currently looks for ANY pending_approval status)
    */
@@ -21,6 +82,8 @@ const UserProfile = props => {
     cohort.members.some(member =>
       member.user.username === username && member.status === "pending_approval"
     ))
+
+  const renderProjectCards = teams => teams.map(team => <ProjectCard key={team.project.id} team={team} />)
 
   const renderCurrentTeam = currentTeams => {
     let card = currentTeams.length > 0 && currentTeams.map((team, index) => {
@@ -105,6 +168,9 @@ const UserProfile = props => {
               pendingApproval.length > 0
               && renderPendingApproval(pendingApproval)
             }
+          </section>
+          <section>
+            {renderProjectCards(teams)}
           </section>
         </main>
       </div>

--- a/src/components/UserProfile/index.jsx
+++ b/src/components/UserProfile/index.jsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { Fragment } from "react";
 import { Link } from "react-router-dom"
 import * as Cards from "../VoyageCard/VoyageCard";
 import UserSideBar from "./UserSideBar";
@@ -7,6 +7,8 @@ import profileQuery from "./graphql/profileQuery"
 import './UserProfile.css'
 import dateFormatter from "../utilities/dateFormatter.js"
 
+
+// PROJECT CARD INFO //
 const InfoComponents = ({ team }) => {
   const { project, cohort, tier, title } = team
   const infoObjects = [
@@ -28,7 +30,7 @@ const InfoComponents = ({ team }) => {
           return (
             <Link to={`/profile/${user.username}`} key={idx} className="team-card-user">
               <img className="team-card-avatar-img" src={user.avatar ? user.avatar : require('../../assets/blank image.png')} alt={user.username} />
-              <div className="team-card-username">{user.username}</div>
+              {/* <div className="team-card-username">{user.username}</div> */}
             </Link>
           )
         })
@@ -45,20 +47,23 @@ const InfoComponents = ({ team }) => {
         break;
     }
     return (
-      <React.Fragment key={idx} >
+      <Fragment key={idx} >
         <div className="project-info__label">{info.label}</div>
         <div className="project-info__data">{data}</div>
-      </React.Fragment>
+      </Fragment>
     )
   })
 }
 
 const ProjectCard = ({ team }) => {
+  const { images } = team.project
   return (
     <div className="project-card__container">
-      <img
-        className="project-img"
-        src="https://placehold.it/325x260" />
+      <Link to={`/project/${team.project.id}`}>
+        <img
+          className="project-img"
+          src={images[0] ? images[0].url : require('../../assets/landingImage.png')} />
+      </Link>
       <div className="project-info__container">
         <InfoComponents team={team} />
       </div>
@@ -66,6 +71,9 @@ const ProjectCard = ({ team }) => {
   )
 }
 
+
+
+// -- USER PROFILE (EXPORT) -- //
 const UserProfile = props => {
   // Only allow editing if no /profile param provided. TODO: Check for currently logged in user
   const editable = !props.match.params.username
@@ -73,7 +81,6 @@ const UserProfile = props => {
   /**
    * TODOS:
    * Check filters
-   * Fix pendingApproval filter (currently looks for ANY pending_approval status)
    */
   const { user, user: { teams, cohorts, username } } = props.data // Fetched user
   const pastTeams = teams.filter(team => team.cohort.status === 'ended');
@@ -83,7 +90,15 @@ const UserProfile = props => {
       member.user.username === username && member.status === "pending_approval"
     ))
 
-  const renderProjectCards = teams => teams.map(team => <ProjectCard key={team.project.id} team={team} />)
+  const renderProjectCards = (currentTeams, pastTeams) => {
+    const mapProjectCards = teamsList => teamsList.map(team => <ProjectCard key={team.project.id} team={team} />)
+    return <Fragment>
+      {!!currentTeams.length && <div className="user-voyage-title">Current Projects</div>}
+      {mapProjectCards(currentTeams)}
+      {!!pastTeams.length && <div className="user-voyage-title">Past Projects</div>}
+      {mapProjectCards(pastTeams)}
+    </Fragment>
+  }
 
   const renderCurrentTeam = currentTeams => {
     let card = currentTeams.length > 0 && currentTeams.map((team, index) => {
@@ -98,15 +113,15 @@ const UserProfile = props => {
       )
     })
     return (
-      <React.Fragment>
+      <Fragment>
         <div className="user-voyage-title">Current Voyages</div>
         {card}
-      </React.Fragment>
+      </Fragment>
     )
   }
 
   const renderPendingApproval = pendingApproval => (
-    <React.Fragment>
+    <Fragment>
       <div className="user-voyage-title">Upcoming Voyages</div>
       {
         pendingApproval.map((cohort, index) =>
@@ -118,7 +133,7 @@ const UserProfile = props => {
             cohort={cohort.title}
           />
         )}
-    </React.Fragment>
+    </Fragment>
   )
 
   const renderNoTeamTypeCards = pendingApproval => {
@@ -141,10 +156,10 @@ const UserProfile = props => {
       card = <NothingHere />
     }
     return (
-      <React.Fragment>
+      <Fragment>
         <div className="user-voyage-title">Current Voyages</div>
         {card}
-      </React.Fragment>
+      </Fragment>
     )
   }
 
@@ -170,7 +185,7 @@ const UserProfile = props => {
             }
           </section>
           <section>
-            {renderProjectCards(teams)}
+            {renderProjectCards(currentTeams, pastTeams)}
           </section>
         </main>
       </div>
@@ -239,10 +254,10 @@ export default props =>
 //       )
 //     })
 //     return (
-//       <React.Fragment>
+//       <Fragment>
 //         <div className="user-voyage-title">Current Voyages</div>
 //         {card}
-//       </React.Fragment>
+//       </Fragment>
 //     )
 //   }
 
@@ -250,7 +265,7 @@ export default props =>
 //     let { pendingApproval } = this.state;
 //     return pendingApproval.map((cohort, index) => {
 //       return (
-//         <React.Fragment key={cohort.id + "_" + index}>
+//         <Fragment key={cohort.id + "_" + index}>
 //           <div className="user-voyage-title">Upcoming Voyages</div>
 //           <Cards.PendingApprovalVoyageCard
 //             key={cohort.id + "_" + index}
@@ -259,7 +274,7 @@ export default props =>
 //             endDate={cohort.end_date}
 //             cohort={cohort.title}
 //           />
-//         </React.Fragment>
+//         </Fragment>
 //       )
 //     })
 //   }
@@ -284,10 +299,10 @@ export default props =>
 //       card = <NothingHere />
 //     }
 //     return (
-//       <React.Fragment>
+//       <Fragment>
 //         <div className="user-voyage-title">Current Voyages</div>
 //         {card}
-//       </React.Fragment>
+//       </Fragment>
 //     )
 //   }
 //   render() {

--- a/src/components/UserProfile/index.jsx
+++ b/src/components/UserProfile/index.jsx
@@ -12,8 +12,8 @@ import dateFormatter from "../utilities/dateFormatter.js"
 const InfoComponents = ({ team }) => {
   const { project, cohort, tier, title } = team
   const infoObjects = [
-    { label: 'Voyage Dates', data: dateFormatter(cohort.start_date) + " - " + dateFormatter(cohort.end_date) },
-    { label: 'Team Name', data: title },
+    { label: 'Voyage', data: `${cohort.title} - ${dateFormatter(cohort.start_date)} - ${dateFormatter(cohort.end_date)}` },
+    { label: 'Team', data: title },
     { label: 'Tier', data: 'Tier ' + tier.level },
     { label: 'Project', data: project.title },
     { label: 'Elevator Pitch', data: project.elevator_pitch },
@@ -174,7 +174,7 @@ const UserProfile = props => {
               && renderPendingApproval(pendingApproval)
             }
           </section>
-          <section>
+          <section className="user-voyage">
             {!!currentTeams.length && <div className="user-voyage-title">Current Projects</div>}
             {renderProjectCards(currentTeams)}
             {!!pastTeams.length && <div className="user-voyage-title">Past Projects</div>}

--- a/src/components/utilities/EditableTextField.jsx
+++ b/src/components/utilities/EditableTextField.jsx
@@ -77,7 +77,7 @@ class EditableTextField extends React.Component {
   handleSubmit = () => {
     const { variables } = this.state;
     const { mutation } = this.props;
-    
+
     client.mutate({ mutation, variables })
       .then(this.handleUpdateData)
       .catch(console.error);
@@ -111,7 +111,7 @@ class EditableTextField extends React.Component {
       const { value } = currentTarget;
       const { variables } = this.state;
       const { mutationInputName, fieldName } = this.props;
-      
+
       variables[mutationInputName][fieldName] = value;
       return { variables };
     },
@@ -131,14 +131,16 @@ class EditableTextField extends React.Component {
     const { edit, displayEdit, variables, updatedData } = this.state;
 
     if (edit) return (
-      <EditArea
-        large={large}
-        data={variables[mutationInputName]}
-        fieldName={fieldName}
-        onSubmit={this.handleSubmit}
-        onCancel={this.handleCancel}
-        onInputChange={this.handleInputChange}
-      />
+      <Component>
+        <EditArea
+          large={large}
+          data={variables[mutationInputName]}
+          fieldName={fieldName}
+          onSubmit={this.handleSubmit}
+          onCancel={this.handleCancel}
+          onInputChange={this.handleInputChange}
+        />
+      </Component>
     );
 
     return (
@@ -148,7 +150,7 @@ class EditableTextField extends React.Component {
         onMouseLeave={() => hasPermission && this.toggleDisplayEdit(false)}
       >
         {displayEdit && <EditButton toggleEdit={this.toggleEdit} />}
-        <Component data={updatedData || fieldData} />
+        <Component>{updatedData || fieldData}</Component>
       </div>
     );
   }


### PR DESCRIPTION
### Summary
- Add project cards to UserProfile
![screenshot from 2018-09-07 22-30-38](https://user-images.githubusercontent.com/6613473/45241693-aaf55c00-b2ed-11e8-9e11-e170216fcb12.png)
- Refactor
  - Get route param from `props.match.params` instead of App.js route wrapper
  - Turn into function
- Fix UserProfile sidebar titles visbility in edit mode
![peek 2018-09-06 20-05](https://user-images.githubusercontent.com/6613473/45241864-57374280-b2ee-11e8-8017-bc4437475214.gif)



#### Todos
- Better styling
- Include projects not related to voyage teams
- Adjust voyage cards (make smaller and move?)


Closes #43 
Closes #47