### PR TITLE
Redirect nonexistent project path to /projects

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -78,8 +78,7 @@ export default () => (
       <Route exact path="/privacy" component={PrivacyPolicy} />
       <Route exact path="/companyfaq" render={() => <FAQ headerText="Company FAQs" data={companyFAQ} />} />
       <Route exact path="/programfaq" render={() => <FAQ headerText="Program FAQs" data={programFAQ} />} />
-      <Route exact path="/project/:projectId" render={
-        ({ match: { params: { projectId } } }) => <ProjectShowcase projectId={projectId}/> } />
+      <Route exact path="/project/:project_id" component={ProjectShowcase} />
       <Route path="*" exact component={Missing404Page} />
     </Switch>
     <Footer />


### PR DESCRIPTION
### Summary 
- Redirect nonexistent project path to `/projects`
- Remove `github_repo_url` from query variables
- Get route param from `props.match.params` and remove App.js wrapper
- Remove unused state

**Questions**
- Can we rename `AllProjects` and `ProjectShowcase` to be clearer?
- `github_repo_id` can be used to get project info, but I'm not seeing a use for this particular View atm. Ok to remove?

Closes #51