### PR TITLE
PopupMenu

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -2,6 +2,7 @@ import React, { Fragment } from "react";
 import { Link, withRouter } from "react-router-dom";
 import PropTypes from "prop-types"
 import Request from "../utilities/Request"
+import Dropdown from "../utilities/Dropdown"
 import Modal from "../common/Modal"
 import GithubLoginModal from "../Login/components/GithubLoginModal"
 import profileQuery from "../UserProfile/graphql/profileQuery"
@@ -10,24 +11,14 @@ import userBaseQuery from "./userBaseQuery"
 import { client } from "../../index"
 
 class Header extends React.Component {
-  state = { showDropdown: false }
-
-  // TODO: Refactor Header methods
   openLoginModal = e => {
     e.stopPropagation()
     this.refs.loginModal.open()
   }
 
-  toggleDropdown = () => {
-    this.refs.dropdownModal.toggle()
-    this.setState({ showDropdown: !this.state.showDropdown })
-  }
-
   logout = async e => {
     e.preventDefault();
     window.localStorage.removeItem("token");
-    window.localStorage.removeItem("store");
-
     /**
      * TODOS: 
      * Server logout logic
@@ -38,24 +29,18 @@ class Header extends React.Component {
   };
 
   renderAvatar = avatar => (
-    <div className="header-dropdown">
+    <Dropdown className="header-dropdown">
       <img
         onClick={this.toggleDropdown}
         className="avatar"
         src={avatar ? avatar : require('../../assets/blank image.png')} alt="user avatar"
       />
-
-      {
-        this.state.showDropdown &&
-        <Fragment>
-          <div className="header-mask" />
-          <div className="header-dropdown-content avatar">
+        <div className="header-dropdown-content">
             <Link
               to="/newsfeed"
             >
               Newsfeed
             </Link>
-
             <Link
               to="/voyage"
               onMouseOver={() => client.query({ query: voyagesQuery })}
@@ -77,9 +62,7 @@ class Header extends React.Component {
             <hr />
             <Link to="/" onClick={e => this.logout(e)}>Log out</Link>
           </div>
-        </Fragment>
-      }
-    </div>
+    </Dropdown>
   )
 
   render() {
@@ -87,11 +70,14 @@ class Header extends React.Component {
     const { user } = this.props.data
     return (
       <Fragment>
-        <Modal onModalClick={this.toggleDropdown} background="none" ref="dropdownModal" />
-        <Modal ref="loginModal" background="transparent"><GithubLoginModal /></Modal>
-        <div
-          onClick={this.toggleDropdown}
-          className={`header header-dark ${this.state.showDropdown ? "modal-peek" : ""}`}>
+        
+        <Modal 
+          ref="loginModal" 
+          background="transparent">
+          <GithubLoginModal />
+        </Modal>
+        
+        <div className="header header-dark">
           <div className="header-container">
             <div className="header-left">
               <div className="nav-logo">

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -34,34 +34,35 @@ class Header extends React.Component {
         onClick={this.toggleDropdown}
         className="avatar"
         src={avatar ? avatar : require('../../assets/blank image.png')} alt="user avatar"
-      />
+        />
         <div className="header-dropdown-content">
-            <Link
-              to="/newsfeed"
+          <Link
+            to="/newsfeed"
             >
-              Newsfeed
-            </Link>
-            <Link
-              to="/voyage"
-              onMouseOver={() => client.query({ query: voyagesQuery })}
+            Newsfeed
+          </Link>
+          <Link
+            to="/voyage"
+            onMouseOver={() => client.query({ query: voyagesQuery })}
+          >
+            Voyage Portal
+          </Link>
+          <Link
+            to="/projects"
             >
-              Voyage Portal
-            </Link>
-            <Link
-              to="/projects"
+            Project Showcase
+          </Link>
+          <hr />
+          <Link
+            to="/profile"
+            // TODO: FIXME Query related error when prefetching while vieweing ProjectShowcase
+            // onMouseOver={() => client.query({ query: profileQuery })}
             >
-              Project Showcase
-            </Link>
-            <hr />
-            <Link
-              to="/profile"
-              onMouseOver={() => client.query({ query: profileQuery })}
-            >
-              User Profile
-            </Link>
-            <hr />
-            <Link to="/" onClick={e => this.logout(e)}>Log out</Link>
-          </div>
+            User Profile
+          </Link>
+          <hr />
+          <Link to="/" onClick={e => this.logout(e)}>Log out</Link>
+        </div>
     </Dropdown>
   )
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -2,7 +2,7 @@ import React, { Fragment } from "react";
 import { Link, withRouter } from "react-router-dom";
 import PropTypes from "prop-types"
 import Request from "../utilities/Request"
-import Dropdown from "../utilities/Dropdown"
+import PopupMenu from "../utilities/PopupMenu"
 import Modal from "../common/Modal"
 import GithubLoginModal from "../Login/components/GithubLoginModal"
 import profileQuery from "../UserProfile/graphql/profileQuery"
@@ -29,7 +29,7 @@ class Header extends React.Component {
   };
 
   renderAvatar = avatar => (
-    <Dropdown className="header-dropdown">
+    <PopupMenu className="header-dropdown">
       <img
         onClick={this.toggleDropdown}
         className="avatar"
@@ -63,7 +63,7 @@ class Header extends React.Component {
           <hr />
           <Link to="/" onClick={e => this.logout(e)}>Log out</Link>
         </div>
-    </Dropdown>
+    </PopupMenu>
   )
 
   render() {

--- a/src/components/utilities/Dropdown.jsx
+++ b/src/components/utilities/Dropdown.jsx
@@ -1,0 +1,65 @@
+import React, { Component, Fragment } from "react"
+import PropTypes from "prop-types"
+import { withRouter } from "react-router-dom"
+
+/**
+ * TODO:
+ * Use onFocus and onBlur synthetic events instead of global eventListeners
+ * Custom error handlers for toggle and menu props
+ * Enable optional props to handle parent state
+ * Add refs to use by the parent
+ * Add option to ersist over route changes
+ */
+
+class Dropdown extends Component {
+  state = { show: false }
+
+  componentDidMount() {
+    document.addEventListener("click", this.handleClick, false)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("click", this.handleClick, false)
+  }
+
+  componentDidUpdate(prevProps) {
+    // Close on route change
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      this.setState({ show: false })
+    }
+  }
+
+  handleClick = e => {
+    const { onDropdownClick, persist } = this.props
+
+    if (onDropdownClick) {
+      return onDropdownClick(e)
+    }
+
+    if (!this.state.show &&
+      this.dropdownToggle.firstChild === e.target) {
+      return this.setState({ show: true })
+    }
+
+    if (
+      !persist &&
+      !this.dropdownMenu.contains(e.target)) {
+      return this.setState({ show: false })
+    }
+  }
+
+  render() {
+    // Get toggle and menu elements from props or props.children
+    let { toggle, menu } = this.props
+    if (!toggle || !menu) ([toggle, menu] = this.props.children)
+
+    return (
+      <div>
+        <div ref={el => this.dropdownToggle = el}>{toggle}</div>
+        <div ref={el => this.dropdownMenu = el}>{this.state.show && menu}</div>
+      </div>
+    )
+  }
+}
+
+export default withRouter(Dropdown)

--- a/src/components/utilities/Dropdown.jsx
+++ b/src/components/utilities/Dropdown.jsx
@@ -12,6 +12,37 @@ import { withRouter } from "react-router-dom"
  */
 
 class Dropdown extends Component {
+  static propTypes = {
+    persist: PropTypes.bool, // Persist over clicks outside of dd menu
+    onDropdownClick: PropTypes.func,
+    toggle: (props, propName, componentName) => {
+      if (props.toggle && !props.menu) {
+        return new Error(`${componentName} requires both 'toggle' and 'menu' props OR two child elements!`)
+      }
+    },
+    menu: (props, propName, componentName) => {
+      if (props.menu && !props.toggle) {
+        return new Error(`${componentName} requires both 'toggle' and 'menu' props OR two child elements!`)
+      }
+    },
+    children: PropTypes.arrayOf(arrayOfChildren => {
+      if (
+        this.toggle && this.menu && !!arrayOfChildren.length
+      ) {
+        console.warn(`Dropdown: 'Toggle' and 'menu' props found. Children will not be used!`)
+      }
+
+      if ((!this.toggle || !this.menu) && arrayOfChildren.length !== 2) {
+        return new Error(`Dropdown requires two child elements - [<toggle/>, <menu/>]!`)
+      }
+    })
+  }
+
+  static defaultProps = {
+    persist: false,
+    children: [] // Prevent non-iterable destructure error when providing only one of 'toggle' and 'menu' props
+  }
+
   state = { show: false }
 
   componentDidMount() {

--- a/src/components/utilities/Dropdown.jsx
+++ b/src/components/utilities/Dropdown.jsx
@@ -4,17 +4,15 @@ import { withRouter } from "react-router-dom"
 
 /**
  * TODO:
- * Use onFocus and onBlur synthetic events instead of global eventListeners
- * Custom error handlers for toggle and menu props
- * Enable optional props to handle parent state
- * Add refs to use by the parent
- * Add option to ersist over route changes
+ * Use onFocus and onBlur synthetic events instead of eventListeners
+ * Add refs to be used by the parent
+ * Add optional prop to allow persistence over route changes
  */
 
 class Dropdown extends Component {
   static propTypes = {
     persist: PropTypes.bool, // Persist over clicks outside of dd menu
-    onDropdownClick: PropTypes.func,
+    // onDropdownClick: PropTypes.func, // TODO:
     toggle: (props, propName, componentName) => {
       if (props.toggle && !props.menu) {
         return new Error(`${componentName} requires both 'toggle' and 'menu' props OR two child elements!`)
@@ -26,9 +24,7 @@ class Dropdown extends Component {
       }
     },
     children: PropTypes.arrayOf(arrayOfChildren => {
-      if (
-        this.toggle && this.menu && !!arrayOfChildren.length
-      ) {
+      if (this.toggle && this.menu && !!arrayOfChildren.length) {
         console.warn(`Dropdown: 'Toggle' and 'menu' props found. Children will not be used!`)
       }
 
@@ -44,6 +40,7 @@ class Dropdown extends Component {
   }
 
   state = { show: false }
+  // TODO: Create refs in constructor and use with domRef in children - for use by the parent
 
   componentDidMount() {
     document.addEventListener("click", this.handleClick, false)
@@ -63,15 +60,13 @@ class Dropdown extends Component {
   handleClick = e => {
     const { onDropdownClick, persist } = this.props
 
-    if (onDropdownClick) {
-      return onDropdownClick(e)
-    }
-
+    // Open DD on toggle element click 
     if (!this.state.show &&
       this.dropdownToggle.firstChild === e.target) {
       return this.setState({ show: true })
     }
 
+    // Close DD on click outside of menu element  (unless props.persist === true)
     if (
       !persist &&
       !this.dropdownMenu.contains(e.target)) {

--- a/src/components/utilities/PopupMenu.jsx
+++ b/src/components/utilities/PopupMenu.jsx
@@ -9,10 +9,10 @@ import { withRouter } from "react-router-dom"
  * Add optional prop to allow persistence over route changes
  */
 
-class Dropdown extends Component {
+class PopupMenu extends Component {
   static propTypes = {
     persist: PropTypes.bool, // Persist over clicks outside of dd menu
-    // onDropdownClick: PropTypes.func, // TODO:
+    // onMenuClick: PropTypes.func, // TODO:
     toggle: (props, propName, componentName) => {
       if (props.toggle && !props.menu) {
         return new Error(`${componentName} requires both 'toggle' and 'menu' props OR two child elements!`)
@@ -25,11 +25,11 @@ class Dropdown extends Component {
     },
     children: PropTypes.arrayOf(arrayOfChildren => {
       if (this.toggle && this.menu && !!arrayOfChildren.length) {
-        console.warn(`Dropdown: 'Toggle' and 'menu' props found. Children will not be used!`)
+        console.warn(`PopupMenu: 'Toggle' and 'menu' props found. Children will not be used!`)
       }
 
       if ((!this.toggle || !this.menu) && arrayOfChildren.length !== 2) {
-        return new Error(`Dropdown requires two child elements - [<toggle/>, <menu/>]!`)
+        return new Error(`PopupMenu requires two child elements - [<toggle/>, <menu/>]!`)
       }
     })
   }
@@ -58,18 +58,18 @@ class Dropdown extends Component {
   }
 
   handleClick = e => {
-    const { onDropdownClick, persist } = this.props
+    const { onMenuClick, persist } = this.props
 
     // Open DD on toggle element click 
     if (!this.state.show &&
-      this.dropdownToggle.firstChild === e.target) {
+      this.toggleElement.firstChild === e.target) {
       return this.setState({ show: true })
     }
 
     // Close DD on click outside of menu element  (unless props.persist === true)
     if (
       !persist &&
-      !this.dropdownMenu.contains(e.target)) {
+      !this.menuElement.contains(e.target)) {
       return this.setState({ show: false })
     }
   }
@@ -81,11 +81,11 @@ class Dropdown extends Component {
 
     return (
       <div>
-        <div ref={el => this.dropdownToggle = el}>{toggle}</div>
-        <div ref={el => this.dropdownMenu = el}>{this.state.show && menu}</div>
+        <div ref={el => this.toggleElement = el}>{toggle}</div>
+        <div ref={el => this.menuElement = el}>{this.state.show && menu}</div>
       </div>
     )
   }
 }
 
-export default withRouter(Dropdown)
+export default withRouter(PopupMenu)

--- a/src/components/utilities/PopupMenu.jsx
+++ b/src/components/utilities/PopupMenu.jsx
@@ -80,7 +80,7 @@ class PopupMenu extends Component {
     if (!toggle || !menu) ([toggle, menu] = this.props.children)
 
     return (
-      <div>
+      <div className={this.props.className}>
         <div ref={el => this.toggleElement = el}>{toggle}</div>
         <div ref={el => this.menuElement = el}>{this.state.show && menu}</div>
       </div>

--- a/src/components/utilities/PopupMenu.jsx
+++ b/src/components/utilities/PopupMenu.jsx
@@ -43,11 +43,11 @@ class PopupMenu extends Component {
   // TODO: Create refs in constructor and use with domRef in children - for use by the parent
 
   componentDidMount() {
-    document.addEventListener("click", this.handleClick, false)
+    document.addEventListener("mousedown", this.handleClick, false)
   }
 
   componentWillUnmount() {
-    document.removeEventListener("click", this.handleClick, false)
+    document.removeEventListener("mousedown", this.handleClick, false)
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/utilities/PopupMenu.jsx
+++ b/src/components/utilities/PopupMenu.jsx
@@ -13,30 +13,30 @@ class PopupMenu extends Component {
   static propTypes = {
     persist: PropTypes.bool, // Persist over clicks outside of dd menu
     // onMenuClick: PropTypes.func, // TODO:
-    toggle: (props, propName, componentName) => {
-      if (props.toggle && !props.menu) {
-        return new Error(`${componentName} requires both 'toggle' and 'menu' props OR two child elements!`)
+    control: (props, propName, componentName) => {
+      if (props.control && !props.menu) {
+        return new Error(`${componentName} requires both 'control' and 'menu' props OR two child elements!`)
       }
     },
     menu: (props, propName, componentName) => {
-      if (props.menu && !props.toggle) {
-        return new Error(`${componentName} requires both 'toggle' and 'menu' props OR two child elements!`)
+      if (props.menu && !props.control) {
+        return new Error(`${componentName} requires both 'control' and 'menu' props OR two child elements!`)
       }
     },
     children: PropTypes.arrayOf(arrayOfChildren => {
-      if (this.toggle && this.menu && !!arrayOfChildren.length) {
-        console.warn(`PopupMenu: 'Toggle' and 'menu' props found. Children will not be used!`)
+      if (this.control && this.menu && !!arrayOfChildren.length) {
+        console.warn(`PopupMenu: 'control' and 'menu' props found. Children will not be used!`)
       }
 
-      if ((!this.toggle || !this.menu) && arrayOfChildren.length !== 2) {
-        return new Error(`PopupMenu requires two child elements - [<toggle/>, <menu/>]!`)
+      if ((!this.control || !this.menu) && arrayOfChildren.length !== 2) {
+        return new Error(`PopupMenu requires two child elements - [<control/>, <menu/>]!`)
       }
     })
   }
 
   static defaultProps = {
     persist: false,
-    children: [] // Prevent non-iterable destructure error when providing only one of 'toggle' and 'menu' props
+    children: [] // Prevent non-iterable destructure error when providing only one of 'control' and 'menu' props
   }
 
   state = { show: false }
@@ -60,9 +60,9 @@ class PopupMenu extends Component {
   handleClick = e => {
     const { onMenuClick, persist } = this.props
 
-    // Open DD on toggle element click 
+    // Open DD on control element click 
     if (!this.state.show &&
-      this.toggleElement.firstChild === e.target) {
+      this.controlElement.firstChild === e.target) {
       return this.setState({ show: true })
     }
 
@@ -75,13 +75,13 @@ class PopupMenu extends Component {
   }
 
   render() {
-    // Get toggle and menu elements from props or props.children
-    let { toggle, menu } = this.props
-    if (!toggle || !menu) ([toggle, menu] = this.props.children)
+    // Get control and menu elements from props or props.children
+    let { control, menu } = this.props
+    if (!control || !menu) ([control, menu] = this.props.children)
 
     return (
       <div className={this.props.className}>
-        <div ref={el => this.toggleElement = el}>{toggle}</div>
+        <div ref={el => this.controlElement = el}>{control}</div>
         <div ref={el => this.menuElement = el}>{this.state.show && menu}</div>
       </div>
     )

--- a/src/styles/layout/_header.scss
+++ b/src/styles/layout/_header.scss
@@ -107,19 +107,20 @@
   }
 }
 
-.header-mask {
-  background-color: black;
-  float: right;
-  width: 30%;
-  height: 100px;
-  position: relative;
-  margin-right: -50px;
-  opacity: 0;
+// .header-mask {
+//   background-color: black;
+//   float: right;
+//   width: 30%;
+//   height: 100px;
+//   position: relative;
+//   margin-right: -50px;
+//   opacity: 0;
   // visibility: visible;
   // &:hover ~ .header-dropdown-content {
   //   visibility: visible;
   // }
-}
+// }
+
 .header-portal-btn {
   display: block;
   margin: 0 auto;
@@ -147,7 +148,7 @@
 }
 
 .header-dropdown {
-  margin: 0 auto;
+  // margin: 0 0 auto auto;
   // width: 100%;
   float: right;
   padding: 2px;

--- a/src/styles/layout/_header.scss
+++ b/src/styles/layout/_header.scss
@@ -148,26 +148,23 @@
 
 .header-dropdown {
   margin: 0 auto;
-  width: 100%;
+  // width: 100%;
   float: right;
   padding: 2px;
-  a:hover {
-    background-color: $pale-purple--hover;
-    color: white;
-  }
 }
-.header-dropdown-content--centered {
-  margin: 0 auto;
-}
-.header-dropdown-content,
-.header-dropdown-content--centered {
-  // visibility: hidden;
-  width: 70%;
+
+.header-dropdown-content {
   display: block;
   background-color: white;
   box-shadow: $box-shadow-dark;
   text-align: center;
   overflow: auto;
+  right: 0;
+  width: fit-content;
+  a:hover {
+    background-color: $pale-purple--hover;
+    color: white;
+  }
   .label {
     color: $theme-purple;
     text-align: center;
@@ -192,13 +189,6 @@
       margin-bottom: 12px;
       font-size: 12px;
     }
-  }
-  // &:hover {
-  //   visibility: visible;
-  // }
-  &.avatar {
-    right: 0;
-    width: fit-content;
   }
   hr {
     border: 1px solid $pale-grey;


### PR DESCRIPTION
#### Summary
- Create utility component to replace modal overlays behind dropdowns
  - No need to handle propagation of multiple modals anymore
  - Allows regular clicks over other links in the page without having to close the modal first
- Refactored Header dropdown styling a bit
#### Requirements
- Requires array of two child elements **OR** `control` and `menu`props
```
propTypes = {
  persist: PropTypes.bool, // Persist over clicks outside of dd menu
  control: PropTypes.element, 
  menu: PropTypes.element,
  children: PropTypes.arrayOf(PropTypes.element)
}
```
#### Usage
```
<Dropdown toggle={React.element} menu={React.element}/>
```
or
```
<Dropdown>
  <div>Control element</div>
  <div>Menu element</div>
</Dropdown>
```

#### Todos
- Allow custom handlers and refs to be used by dropdown parent (currently handles its own state)
- Use `onFocus` and `onBlur` with `tabIndex` instead of `eventListener`
- Add prop to enable persistence over route changes (needed?)

Closes #80 