### PR TITLE
New/introspect site features

### DIFF
--- a/src/components/Ticketbox/components/Feedback/BugSuggestion.jsx
+++ b/src/components/Ticketbox/components/Feedback/BugSuggestion.jsx
@@ -7,6 +7,7 @@ import { QA } from "./BugSuggestionQA";
 import Success from "../Success";
 import TicketBoxError from "../TicketBoxError";
 import BackBtn from "../BackBtn";
+import { introspectEnum, Request } from "../../../utilities";
 
 class BugSuggestion extends React.Component {
   state = { error: null, response: null };
@@ -38,7 +39,7 @@ class BugSuggestion extends React.Component {
   }
 
   render() {
-    const { category, switchRenderedType } = this.props;
+    const { category, switchRenderedType, data: { siteLocationsEnum } } = this.props;
     const { error, response } = this.state;
     const imgFile = category === 'bug' ? 'Artboard 3-small.png' : 'Artboard 2-small.png';
     const imgSrc = require(`../../../../assets/${imgFile}`);
@@ -50,7 +51,7 @@ class BugSuggestion extends React.Component {
       <div className="ticketbox-form">
         <DynamicFormContainer
           hiddenData={{ category }}
-          questions={QA(category)}
+          questions={QA(category, siteLocationsEnum.options)}
           onSubmit={this.submitTicket}
           persistence
           purpose={`ticketbox-${category}`}
@@ -75,4 +76,17 @@ BugSuggestion.propTypes = {
   switchRenderedType: PropTypes.func.isRequired,
 }
 
-export default BugSuggestion;
+const siteLocationEnumQuery = introspectEnum(
+  'UserFeedbackSiteLocationEnum',
+  'siteLocationsEnum',
+  'BugSuggestionSiteLocationsEnumQuery',
+);
+
+export default props => (
+  <Request
+    {...props}
+    query={siteLocationEnumQuery}
+    component={BugSuggestion}
+    loader
+  />
+);

--- a/src/components/Ticketbox/components/Feedback/BugSuggestionQA.js
+++ b/src/components/Ticketbox/components/Feedback/BugSuggestionQA.js
@@ -1,4 +1,12 @@
-export const QA = (category) => [
+const mapSiteLocationOptions = ({ name }) => {
+  // project_showcase -> project showcase (user facing text)
+  const text = name.split('_').join(' '); // CSS handles uppercasing
+  // preserve snakecase naming for value submitted to API
+  const value = name;
+  return { text, value };
+};
+
+export const QA = (category, siteLocations) => [
     {
       text: 'Category',
       input_type: 'hidden',
@@ -22,22 +30,7 @@ export const QA = (category) => [
       text: 'Site Feature',
       input_type: 'dropdown',
       field_name: 'site_location',
-      options: [
-        'FAQ',
-        'landing',
-        'login',
-        'newsfeed_all',
-        'newsfeed_team',
-        'other',
-        'profile',
-        'project',
-        'project_showcase',
-        'registration',
-        'team_standup',
-        'ticketbox',
-        'voyages',
-        'voyage_application'
-      ]
+      options: siteLocations.map(mapSiteLocationOptions),
     },
     {
       text: 'Title',

--- a/src/components/utilities/index.jsx
+++ b/src/components/utilities/index.jsx
@@ -1,0 +1,7 @@
+import introspectEnum from "./introspectEnum";
+import Request from "./Request";
+
+export {
+  introspectEnum,
+  Request
+};

--- a/src/components/utilities/introspectEnum.js
+++ b/src/components/utilities/introspectEnum.js
@@ -1,0 +1,27 @@
+const { gql } = require("apollo-boost");
+
+/**
+ * @param {string} enumName name of the Enum to get values from
+ * @param {string} dataDotName name of the property to access the enum values (data.dataDotName.options)
+ * @param {string} queryName [optional] rename the query for logging. default: EnumInstrospectionQuery
+ * @returns {object} introspectionQuery (gql``) object
+ */
+const introspectEnum = (
+  enumName,
+  dataDotName,
+  queryName,
+) => {
+  const queryDef = `
+    query ${queryName || "EnumInstrospectionQuery"} {
+      ${dataDotName}: __type(name: "${enumName}") {
+          name
+          options: enumValues {
+            name
+          }
+      }
+    }
+  `;
+  return gql(queryDef);
+}
+
+export default introspectEnum;


### PR DESCRIPTION
removed hardcoding of site features
introspects our api for the site locations enum to keep single source of truth
adds a utility for introspecting any other enums as needed
refactored BugSuggestion to use new introspection options source
refactored BugSuggestionQA to map enum into { text, value } options
- shows Site Location Name text to user, stores and sends site_location_name value to API

Before:
- prone to error in synchronizing
- snake case labels
![screen shot 2018-11-06 at 3 33 19 am](https://user-images.githubusercontent.com/25523682/48052037-d1f8ce80-e174-11e8-81d1-111647fac503.png)


After:
- automatically synced with api on load
- human readable labels
![screen shot 2018-11-06 at 3 32 24 am](https://user-images.githubusercontent.com/25523682/48052061-e8068f00-e174-11e8-8361-29eac3475d7a.png)
