### PR TITLE
Ref/get uri

### DIFF
--- a/src/components/Login/components/GithubLoginModal.jsx
+++ b/src/components/Login/components/GithubLoginModal.jsx
@@ -1,9 +1,7 @@
 import React from "react"
+import { clientID } from "../../../get_uri";
 
-// TODO: refactor styles
-const GithubLoginModal = ({
-  clientID = "e015fd9cc874fa5a34bf"
-}) => {
+const GithubLoginModal = () => {
   const githubAuthURL = `
   https://github.com/login/oauth/authorize?client_id=${clientID}&scope=public_repo
   `;

--- a/src/get_uri.js
+++ b/src/get_uri.js
@@ -1,12 +1,16 @@
 const getURI = (mode) => {
   switch(mode) {
-    case 'local': return 'http://localhost:8008/graphql';
-    case 'production': return 'https://main-api.chingu.io/graphql';
+    case 'local':
+      return { uri: 'http://localhost:3500/graphql', clientID: "84a3576a59110d11cd6f" };
+    case 'production':
+      return  { uri: 'https://main-api.chingu.io/graphql', clientID: "e015fd9cc874fa5a34bf" };
     case 'staging':
-    default: return 'https://main-api-staging.chingu.io/graphql';
+    default: 
+      return { uri: 'https://main-api-staging.chingu.io/graphql', clientID: "84a3576a59110d11cd6f" };
   }
 }
 // TODO: change this mode as needed. NEVER commit unless set to 'production'
 const mode = 'production';
-const uri = getURI(mode);
+const { uri, clientID } = getURI(mode);
+export { mode, clientID };
 export default uri;


### PR DESCRIPTION
sets both the `uri` and `clientID` fields based on `mode`
GithubLoginModal uses imported `clientID` to control staging vs prod logins (no more resetting the goddamn login endpoint lol)